### PR TITLE
Add test for game logic and refactor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,11 +59,14 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
     // Konfetti
     implementation 'nl.dionsegijn:konfetti-xml:2.0.1'
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'io.mockk:mockk:1.12.3'
+
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,7 +64,6 @@ dependencies {
     implementation 'nl.dionsegijn:konfetti-xml:2.0.1'
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'io.mockk:mockk:1.12.3'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/java/com/ashlett/memory/GameActivity.kt
+++ b/app/src/main/java/com/ashlett/memory/GameActivity.kt
@@ -39,9 +39,11 @@ class GameActivity : AppCompatActivity(), GameView {
         }
     }
 
-    override fun renderView(list: List<Item>) {
+    override fun renderView(list: List<Item>, changedPositions: List<Int>) {
         itemAdapter.itemList = list
-        itemAdapter.notifyItemRangeChanged(0, list.size)
+        for (position in changedPositions) {
+            itemAdapter.notifyItemChanged(position)
+        }
     }
 
     override fun gameOver() {

--- a/app/src/main/java/com/ashlett/memory/GameLogic.kt
+++ b/app/src/main/java/com/ashlett/memory/GameLogic.kt
@@ -15,16 +15,19 @@ class GameLogic(
         return true
     }
 
-    fun makeMove(position: Int) {
+    fun makeMove(position: Int): MutableList<Int> {
+        val changedPositions: MutableList<Int> = mutableListOf(position)
         if (getVisibleItemCount() % 2 == 0) {
-            hideItemsWithoutPairs()
+            hideItemsWithoutPairs(changedPositions)
         }
         showItemAt(position)
+        return changedPositions
     }
 
-    private fun hideItemsWithoutPairs() {
+    private fun hideItemsWithoutPairs(changedPositions: MutableList<Int>) {
         for (position in getPositionsOfItemsWithoutPairs()) {
             setVisibility(position, false)
+            changedPositions.add(position)
         }
     }
 

--- a/app/src/main/java/com/ashlett/memory/GameLogic.kt
+++ b/app/src/main/java/com/ashlett/memory/GameLogic.kt
@@ -1,16 +1,8 @@
 package com.ashlett.memory
 
-class GameLogic {
-    private val itemList: List<Item> = listOf(
-        Item("\uD83D\uDE42"), Item("\uD83D\uDE42"),
-        Item("\uD83D\uDC25"), Item("\uD83D\uDC25"),
-        Item("\uD83D\uDC1F"), Item("\uD83D\uDC1F"),
-        Item("⭐️"), Item("⭐️"),
-        Item("\uD83C\uDF4E"), Item("\uD83C\uDF4E"),
-        Item("⚽️"), Item("⚽️"),
-        Item("\uD83D\uDD6F"), Item("\uD83D\uDD6F"),
-        Item("❤️"), Item("❤️"),
-    ).shuffled()
+class GameLogic(
+    private val itemList: MutableList<Item> = ItemListMaker().makeList()
+) {
 
     fun getItemList() = itemList
 
@@ -31,29 +23,34 @@ class GameLogic {
     }
 
     private fun hideItemsWithoutPairs() {
-        for (item in getItemsWithoutPairs()) {
-            item.isVisible = false
+        for (position in getPositionsOfItemsWithoutPairs()) {
+            setVisibility(position, false)
         }
     }
 
     private fun showItemAt(position: Int) {
-        itemList[position].isVisible = true
+        setVisibility(position, true)
     }
 
-    private fun getItemsWithoutPairs(): List<Item> {
-        val soloItems: MutableList<Item> = mutableListOf()
-        for (item1 in itemList) {
-            if (item1.isVisible && !hasPair(item1)) {
-                soloItems.add(item1)
+    private fun setVisibility(position: Int, isVisible: Boolean) {
+        val newItem = itemList[position].copy(isVisible = isVisible)
+        itemList[position] = newItem
+    }
+
+    private fun getPositionsOfItemsWithoutPairs(): List<Int> {
+        val soloItems: MutableList<Int> = mutableListOf()
+        for ((index, item) in itemList.withIndex()) {
+            if (item.isVisible && !hasPair(index, item)) {
+                soloItems.add(index)
             }
         }
         return soloItems
     }
 
-    private fun hasPair(item1: Item): Boolean {
+    private fun hasPair(index1: Int, item1: Item): Boolean {
         var hasPair = false
-        for (item2 in itemList) {
-            if (item2 != item1 && item2.text == item1.text && item2.isVisible) {
+        for ((index2, item2) in itemList.withIndex()) {
+            if (index2 != index1 && item2.text == item1.text && item2.isVisible) {
                 hasPair = true
             }
         }

--- a/app/src/main/java/com/ashlett/memory/GamePresenter.kt
+++ b/app/src/main/java/com/ashlett/memory/GamePresenter.kt
@@ -7,7 +7,8 @@ class GamePresenter(
 
     override fun start(view: GameView) {
         this.view = view
-        view.renderView(game.getItemList())
+        val itemList = game.getItemList()
+        view.renderView(itemList, IntRange(0, itemList.size - 1).toList())
     }
 
     override fun stop() {
@@ -15,10 +16,10 @@ class GamePresenter(
     }
 
     fun makeMove(position: Int) {
-        game.makeMove(position)
+        val changedPositions: List<Int> = game.makeMove(position)
         if (game.isWon()) {
             view?.gameOver()
         }
-        view?.renderView(game.getItemList())
+        view?.renderView(game.getItemList(), changedPositions)
     }
 }

--- a/app/src/main/java/com/ashlett/memory/GameView.kt
+++ b/app/src/main/java/com/ashlett/memory/GameView.kt
@@ -1,6 +1,6 @@
 package com.ashlett.memory
 
 interface GameView {
-    fun renderView(list: List<Item>)
+    fun renderView(list: List<Item>, changedPositions: List<Int>)
     fun gameOver()
 }

--- a/app/src/main/java/com/ashlett/memory/Item.kt
+++ b/app/src/main/java/com/ashlett/memory/Item.kt
@@ -1,6 +1,6 @@
 package com.ashlett.memory
 
-class Item(
+data class Item(
     val text: String,
-    var isVisible: Boolean = false,
+    val isVisible: Boolean = false,
 )

--- a/app/src/main/java/com/ashlett/memory/ItemListMaker.kt
+++ b/app/src/main/java/com/ashlett/memory/ItemListMaker.kt
@@ -1,0 +1,28 @@
+package com.ashlett.memory
+
+class ItemListMaker {
+    private val repetitions: Int = 2
+    private val itemTextStrings: List<String> = listOf(
+        "\uD83D\uDE42", // smiley
+        "\uD83D\uDC25", // chicken
+        "\uD83D\uDC1F", // fish
+        "⭐️", // star
+        "\uD83C\uDF4E", // apple
+        "⚽️", // football
+        "\uD83D\uDD6F", // candle
+        "❤️", // heart
+    )
+
+    fun makeList(): MutableList<Item> {
+        val itemList: MutableList<Item> = mutableListOf()
+        for (text in itemTextStrings) {
+            repeat(repetitions) {
+                itemList.add(
+                    Item(text, false)
+                )
+            }
+        }
+        itemList.shuffle()
+        return itemList
+    }
+}

--- a/app/src/test/java/com/ashlett/memory/GameLogicTest.kt
+++ b/app/src/test/java/com/ashlett/memory/GameLogicTest.kt
@@ -1,0 +1,83 @@
+package com.ashlett.memory
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GameLogicTest {
+
+    @Test
+    fun testIsWonFalseIfAllInvisible() {
+        val gameLogic = GameLogic(
+            mutableListOf(
+                Item("A", false), Item("A", false),
+                Item("B", false), Item("B", false),
+            )
+        )
+        assertFalse(gameLogic.isWon())
+    }
+
+    @Test
+    fun testIsWonFalseIfSomeInvisible() {
+        val gameLogic = GameLogic(
+            mutableListOf(
+                Item("A", true), Item("A", false),
+                Item("B", false), Item("B", true),
+            )
+        )
+        assertFalse(gameLogic.isWon())
+    }
+
+    @Test
+    fun testIsWonTrueIfAllVisible() {
+        val gameLogic = GameLogic(
+            mutableListOf(
+                Item("A", true), Item("A", true),
+                Item("B", true), Item("B", true),
+            )
+        )
+        assertTrue(gameLogic.isWon())
+    }
+
+    @Test
+    fun testMakeFirstMove() {
+        val gameLogic = GameLogic(
+            mutableListOf(
+                Item("A", false), Item("A", false),
+                Item("B", false), Item("B", false),
+            )
+        )
+        gameLogic.makeMove(0)
+        assertTrue(gameLogic.getItemList()[0].isVisible)
+    }
+
+    @Test
+    fun testMakeThirdMoveWithPair() {
+        val gameLogic = GameLogic(
+            mutableListOf(
+                Item("A", true), Item("A", true),
+                Item("B", false), Item("B", false),
+            )
+        )
+        gameLogic.makeMove(2)
+        for (index in listOf<Int>(0, 1, 2)) {
+            assertTrue(gameLogic.getItemList()[index].isVisible)
+        }
+        assertFalse(gameLogic.getItemList()[3].isVisible)
+    }
+
+    @Test
+    fun testMakeThirdMoveWithoutPair() {
+        val gameLogic = GameLogic(
+            mutableListOf(
+                Item("A", true), Item("A", false),
+                Item("B", true), Item("B", false),
+            )
+        )
+        gameLogic.makeMove(1)
+        for (index in listOf<Int>(0, 2, 3)) {
+            assertFalse(gameLogic.getItemList()[index].isVisible)
+        }
+        assertTrue(gameLogic.getItemList()[1].isVisible)
+    }
+}

--- a/app/src/test/java/com/ashlett/memory/GameLogicTest.kt
+++ b/app/src/test/java/com/ashlett/memory/GameLogicTest.kt
@@ -1,5 +1,6 @@
 package com.ashlett.memory
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -47,7 +48,8 @@ class GameLogicTest {
                 Item("B", false), Item("B", false),
             )
         )
-        gameLogic.makeMove(0)
+        val changedPositions = gameLogic.makeMove(0)
+        assertEquals(changedPositions, listOf(0))
         assertTrue(gameLogic.getItemList()[0].isVisible)
     }
 
@@ -59,7 +61,8 @@ class GameLogicTest {
                 Item("B", false), Item("B", false),
             )
         )
-        gameLogic.makeMove(2)
+        val changedPositions = gameLogic.makeMove(2)
+        assertEquals(changedPositions, listOf(2))
         for (index in listOf<Int>(0, 1, 2)) {
             assertTrue(gameLogic.getItemList()[index].isVisible)
         }
@@ -74,7 +77,8 @@ class GameLogicTest {
                 Item("B", true), Item("B", false),
             )
         )
-        gameLogic.makeMove(1)
+        val changedPositions = gameLogic.makeMove(1)
+        assertEquals(changedPositions, listOf(1, 0, 2))
         for (index in listOf<Int>(0, 2, 3)) {
             assertFalse(gameLogic.getItemList()[index].isVisible)
         }


### PR DESCRIPTION
This PR adds unit tests for `GameLogic` class as well as some improvements that tests helped come up with:
* change `Item` to be immutable and make `itemList` mutable instead
* factor out `itemList` creation to its own class `ItemListMaker`
    * simplifies tests (can use non-shuffled and shorter list in tests)
    * the way it's written opens a door in the future to vary sets of items and number of repetitions
* return positions of changed items from `makeMove` and use them to notify `ItemAdapter`
    * makes the UI respond faster to clicks (max 3 notifications instead of 16 each time)
    * without reverting to `notifyItemSetChanged` (that is discouraged and linters don't like it)